### PR TITLE
CTRL+Enter=submit and Escape=cancel

### DIFF
--- a/telegram-translation-shortcuts.user.js
+++ b/telegram-translation-shortcuts.user.js
@@ -67,33 +67,53 @@ function scrollItems (down) {
 }
 
 /**
- * Clicks the 'Add Translation' button
+ * A div (key-add-suggestion-wrap) contains the input-form to Add translation with Submit and Cancel buttons
+ * This function will check if that div is collapsed or not. If it is collapsed,
+ * it's className will change to 'key-add-suggestion-wrap collapsed'
+ *
+ * @function inputWrapCollapsed() -- Checks if element by class 'key-add-suggestion-wrap' is exactly the same. If not the same, then it is collapsed
+ * @returns True if collapsed
+ * @returns False if NOT collapsed
  */
-function addTranslation () {
-  // don't click if input box is expanded
-  var input_wrapper_collapsed = (document.getElementsByClassName('key-add-suggestion-wrap')[0].className == 'key-add-suggestion-wrap');
-  
-  if (!input_wrapper_collapsed)   // don't toggle 'add' and 'cancel'
-    document.getElementsByClassName('key-add-suggestion-header').item(0).click() 
-  else
-    document.getElementsByClassName('input form-control tr-form-control key-add-suggestion-field').item(0).focus() //fixme: throws undefined error
+function inputWrapCollapsed () {
+  if (document.getElementsByClassName('key-add-suggestion-wrap')[0].className === 'key-add-suggestion-wrap') { // checking if it is NOT collapsed
+    return false
+  } else return true
 }
 
 /**
- * Clicks the edit icon
+ * Clicks the 'Add Translation' button
+ */
+function addTranslation () {
+  if (!inputWrapCollapsed()) { // Don't toggle 'add' and 'cancel'
+    document.getElementsByClassName('key-add-suggestion-header').item(0).click()
+  } else { // Give focus back to input box (don't lose what was typed)
+    document.getElementsByClassName('input form-control tr-form-control key-add-suggestion-field').item(0).focus()
+  }
+}
+
+/**
+ * Clicks the edit icon.
+ * Useful when a suggestion exists but no translation is applied.
  */
 function editTranslation () {
-  document.getElementsByClassName('ibtn key-suggestion-edit').item(0).click()
+  // Don't click if already typing something
+  if (!inputWrapCollapsed()) {
+    document.getElementsByClassName('ibtn key-suggestion-edit').item(0).click()
+  } else { // Give focus back to input box (don't lose what was typed)
+    document.getElementsByClassName('input form-control tr-form-control key-add-suggestion-field').item(0).focus()
+  }
 }
 
 /**
  * Clicks the cancel button
  */
 function cancelTranslation () {
-  // restrict when cancel button can be pressed
-  if (document.getElementsByClassName('key-add-suggestion-wrap')[0].className == 'key-add-suggestion-wrap') {
-    document.getElementsByClassName('btn btn-default form-cancel-btn').item(0).focus();
-    document.getElementsByClassName('btn btn-default form-cancel-btn').item(0).click();
+  // Prevent possible glitch: Don't cancel if wrapper is collapsed, but focus is in a 'form-control' element
+  if (!inputWrapCollapsed) {
+    // Don't allow input-forms to keep the focus after cancel or else shortcuts won't work
+    document.getElementsByClassName('btn btn-default form-cancel-btn').item(0).focus()
+    document.getElementsByClassName('btn btn-default form-cancel-btn').item(0).click()
   }
 }
 
@@ -101,19 +121,21 @@ function cancelTranslation () {
  * Clicks the submit button
  */
 function submitTranslation () {
-  // restrict when submit button can be pressed
-  if (document.getElementsByClassName('key-add-suggestion-wrap')[0].className == 'key-add-suggestion-wrap') {
+  // Prevent possible glitch: Don't submit if wrapper is collapsed, but focus is in a 'form-control' element
+  if (!inputWrapCollapsed()) {
     document.getElementsByClassName('btn btn-primary form-submit-btn').item(0).focus()
     document.getElementsByClassName('btn btn-primary form-submit-btn').item(0).click()
   }
 }
 
 /**
- * Clicks the delete icon
- */
-/*
-function deleteTranslation () {
-  document.getElementsByClassName('ibtn key-suggestion-delete').item(selectedTranslation).click()
+ * Clicks the delete icon of selected suggestion (not yet used)
+ * @param {number} selected - Suggestion item which is in focus/selected
+ *
+function deleteSuggestion (selected) {
+  if (selected != null) {
+    document.getElementsByClassName('ibtn key-suggestion-delete').item(selected).click()
+  }
 } */
 
 /**
@@ -161,14 +183,15 @@ function openSearch () {
  * @param {KeyboardEvent} e - event to handle
  */
 function handleShortcut (e) {
-  
-  // handle shortcuts inside input forms
-  if (e.target.classList.contains('form-control')){
+  // Handle shortcuts inside input forms
+  if (e.target.classList.contains('form-control')) {
     // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
     switch (e.key) {
       // Cancel translation
-      case 'Escape':
-        if (!e.ctrlKey) cancelTranslation()
+      case 'Escape' | 'Esc':
+        if (!e.ctrlKey) {
+          cancelTranslation() // FIXME: Doesn't work in search results
+        }
         break
 
       // Submit translation
@@ -177,11 +200,12 @@ function handleShortcut (e) {
         break
 
       default:
-        return  // Don't handle below shortcuts in input forms
+        // don't use e.preventDefault() or else TAB to next input-form won't work
+        return // Don't try to handle below shortcuts inside input forms
     }
   }
-  
-  // handle shortcuts when not inside input forms
+
+  // Handle shortcuts outside input forms
   var matchedCode = true
   // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code#Code_values
   switch (e.code) {

--- a/telegram-translation-shortcuts.user.js
+++ b/telegram-translation-shortcuts.user.js
@@ -72,10 +72,12 @@ function scrollItems (down) {
 function addTranslation () {
   // don't click if input box is expanded
   var input_wrapper_collapsed = (document.getElementsByClassName('key-add-suggestion-wrap')[0].className == 'key-add-suggestion-wrap');
-  if (!input_wrapper_collapsed)
-    document.getElementsByClassName('key-add-suggestion-header').item(0).click()
+  
+  if (!input_wrapper_collapsed)   // don't toggle 'add' and 'cancel'
+    document.getElementsByClassName('key-add-suggestion-header').item(0).click() 
+  else
+    document.getElementsByClassName('input form-control tr-form-control key-add-suggestion-field').item(0).focus() //fixme: throws undefined error
 }
-// 'Add' and 'Cancel' toggles with: 'key-add-suggestion-header'
 
 /**
  * Clicks the edit icon
@@ -88,23 +90,22 @@ function editTranslation () {
  * Clicks the cancel button
  */
 function cancelTranslation () {
-  document.getElementsByClassName('btn btn-default form-cancel-btn').item(0).click()
-}  
-// toggle add and cancel with: ClassName('key-add-suggestion-header')
+  // restrict when cancel button can be pressed
+  if (document.getElementsByClassName('key-add-suggestion-wrap')[0].className == 'key-add-suggestion-wrap') {
+    document.getElementsByClassName('btn btn-default form-cancel-btn').item(0).focus();
+    document.getElementsByClassName('btn btn-default form-cancel-btn').item(0).click();
+  }
+}
 
 /**
  * Clicks the submit button
  */
 function submitTranslation () {
-<<<<<<< HEAD
-  document.getElementsByClassName('btn btn-primary form-submit-btn').item(0).click()
-=======
   // restrict when submit button can be pressed
   if (document.getElementsByClassName('key-add-suggestion-wrap')[0].className == 'key-add-suggestion-wrap') {
     document.getElementsByClassName('btn btn-primary form-submit-btn').item(0).focus()
     document.getElementsByClassName('btn btn-primary form-submit-btn').item(0).click()
   }
->>>>>>> 594d017... restrict handling of ctrl+enter and escape only inside forms
 }
 
 /**
@@ -161,7 +162,7 @@ function openSearch () {
  */
 function handleShortcut (e) {
   
-  // Shortcuts inside input forms
+  // handle shortcuts inside input forms
   if (e.target.classList.contains('form-control')){
     // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
     switch (e.key) {
@@ -176,13 +177,11 @@ function handleShortcut (e) {
         break
 
       default:
-        // Don't handle below shortcuts in input forms
-        return
+        return  // Don't handle below shortcuts in input forms
     }
   }
   
-  // handle these when not inside input form
-  
+  // handle shortcuts when not inside input forms
   var matchedCode = true
   // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code#Code_values
   switch (e.code) {

--- a/telegram-translation-shortcuts.user.js
+++ b/telegram-translation-shortcuts.user.js
@@ -70,8 +70,12 @@ function scrollItems (down) {
  * Clicks the 'Add Translation' button
  */
 function addTranslation () {
-  document.getElementsByClassName('key-add-suggestion-header').item(0).click()
+  // don't click if input box is expanded
+  var input_wrapper_collapsed = (document.getElementsByClassName('key-add-suggestion-wrap')[0].className == 'key-add-suggestion-wrap');
+  if (!input_wrapper_collapsed)
+    document.getElementsByClassName('key-add-suggestion-header').item(0).click()
 }
+// 'Add' and 'Cancel' toggles with: 'key-add-suggestion-header'
 
 /**
  * Clicks the edit icon
@@ -79,6 +83,37 @@ function addTranslation () {
 function editTranslation () {
   document.getElementsByClassName('ibtn key-suggestion-edit').item(0).click()
 }
+
+/**
+ * Clicks the cancel button
+ */
+function cancelTranslation () {
+  document.getElementsByClassName('btn btn-default form-cancel-btn').item(0).click()
+}  
+// toggle add and cancel with: ClassName('key-add-suggestion-header')
+
+/**
+ * Clicks the submit button
+ */
+function submitTranslation () {
+<<<<<<< HEAD
+  document.getElementsByClassName('btn btn-primary form-submit-btn').item(0).click()
+=======
+  // restrict when submit button can be pressed
+  if (document.getElementsByClassName('key-add-suggestion-wrap')[0].className == 'key-add-suggestion-wrap') {
+    document.getElementsByClassName('btn btn-primary form-submit-btn').item(0).focus()
+    document.getElementsByClassName('btn btn-primary form-submit-btn').item(0).click()
+  }
+>>>>>>> 594d017... restrict handling of ctrl+enter and escape only inside forms
+}
+
+/**
+ * Clicks the delete icon
+ */
+/*
+function deleteTranslation () {
+  document.getElementsByClassName('ibtn key-suggestion-delete').item(selectedTranslation).click()
+} */
 
 /**
  * Applies the most popular translation, switches to next item
@@ -125,9 +160,29 @@ function openSearch () {
  * @param {KeyboardEvent} e - event to handle
  */
 function handleShortcut (e) {
-  // Don't override in input forms
-  if (e.target.classList.contains('form-control')) return
+  
+  // Shortcuts inside input forms
+  if (e.target.classList.contains('form-control')){
+    // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
+    switch (e.key) {
+      // Cancel translation
+      case 'Escape':
+        if (!e.ctrlKey) cancelTranslation()
+        break
 
+      // Submit translation
+      case 'Enter':
+        if (e.ctrlKey) submitTranslation()
+        break
+
+      default:
+        // Don't handle below shortcuts in input forms
+        return
+    }
+  }
+  
+  // handle these when not inside input form
+  
   var matchedCode = true
   // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code#Code_values
   switch (e.code) {

--- a/telegram-translation-shortcuts.user.js
+++ b/telegram-translation-shortcuts.user.js
@@ -2,6 +2,7 @@
 // @name         Telegram Translation Platform Shortcuts
 // @namespace    https://github.com/jurf/telegram-translation-shortcuts
 // @description  Adds useful keyboard shortcuts to the Telegram Translation Platform
+// @Author       Juraj Fiala
 // @include      https://translations.telegram.org/*
 // @version      0.3.2
 // @grant        none
@@ -190,6 +191,7 @@ function handleShortcut (e) {
       // Cancel translation
       case 'Escape' | 'Esc':
         if (!e.ctrlKey) {
+          e.stopImmediatePropagation()
           cancelTranslation() // FIXME: Doesn't work in search results
         }
         break
@@ -200,7 +202,6 @@ function handleShortcut (e) {
         break
 
       default:
-        // don't use e.preventDefault() or else TAB to next input-form won't work
         return // Don't try to handle below shortcuts inside input forms
     }
   }
@@ -234,10 +235,10 @@ function handleShortcut (e) {
   switch (e.key) {
     // Cycle bindings
     case 'l':
-      if (!e.ctrlKey) cycleBindings(true)
+      if (!e.ctrlKey) cycleBindings(true); else matchedKey = false
       break
     case 'h':
-      if (!e.ctrlKey) cycleBindings(false)
+      if (!e.ctrlKey) cycleBindings(false); else matchedKey = false
       break
     case 'Tab':
       cycleBindings(!e.shiftKey)
@@ -252,7 +253,7 @@ function handleShortcut (e) {
       break
 
     case 'k':
-      if (!e.ctrlKey) scrollItems(false)
+      if (!e.ctrlKey) scrollItems(false); else matchedKey = false
       break
     case 'PageUp':
       scrollItems(false)
@@ -260,15 +261,15 @@ function handleShortcut (e) {
 
     // Add new translation
     case 'i':
-      if (!e.ctrlKey) addTranslation()
+      if (!e.ctrlKey) addTranslation(); else matchedKey = false
       break
     case 'a':
-      if (e.ctrlKey) addTranslation()
+      if (e.ctrlKey) addTranslation(); else matchedKey = false
       break
 
     // Edit translation
     case 'c':
-      if (!e.ctrlKey) editTranslation()
+      if (!e.ctrlKey) editTranslation(); else matchedKey = false // allow ctrl+c to copy
       break
     case 'e':
       if (e.ctrlKey) editTranslation()
@@ -276,10 +277,10 @@ function handleShortcut (e) {
 
     // Confirm top translation
     case 'y':
-      if (!e.ctrlKey) quickApply(-1)
+      if (!e.ctrlKey) quickApply(-1); else matchedKey = false
       break
     case 'Enter':
-      if (e.ctrlKey) quickApply(-1)
+      if (e.ctrlKey) quickApply(-1); else matchedKey = false
       break
 
     // Open search


### PR DESCRIPTION
**Hightlights:**
- `ctrl+enter` to submit translation when you're typing; it still works for applying popular suggestion
- `esc` to cancel translation
- `ctrl+a` or `i` for adding translation, when text input is not in focus, but is already expanded, will now focus to the textbox, instead of resetting what you had typed.

Issues with this pull have been fixed. Please review.